### PR TITLE
Fixes #65

### DIFF
--- a/HSPI/Connector.cs
+++ b/HSPI/Connector.cs
@@ -64,6 +64,8 @@ namespace Hspi
                     Console.WriteLine($"Unhandled exception from Plugin: {ex.Message}");
                 }
             }
+
+            Environment.Exit(0);
         }
     }
 }


### PR DESCRIPTION
## Summary

Calls `Environment.Exit(0)` at the end of the `Connector` logic. I'm guessing there's some thread logic behind that scenes that's preventing the thread from shutting down on its own. 

## Description

This is the first bug fix PR in the HSPI nuget package that has a positive effect on everyone who uses the library!!!!!  And that, my friends, is why we're doing this thing! 

## Related Issue

#65

## Motivation and Context

Makes sense according to the conversation in #65. "Disconnect" is a strange concept to me.. Might should be called "Shut down"? I dunno. There's no way to "Reconnect" so it's just strange. 

## How Has This Been Tested

I loaded the HSPI solution and ran the `HSPIPluginA.Dev` project to verify that I could connect to HS. I then disconnected the plugin as described in #65. The plugin console window almost immediately shuts down now. Before the code change, it didn't shut down. 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **CODE OF CONDUCT** document.
- [x] I have added tests to cover my changes if possible
- [x] All new and existing tests passed.