### PR TITLE
Fixed: #81

### DIFF
--- a/HSPI/Connector.cs
+++ b/HSPI/Connector.cs
@@ -16,10 +16,14 @@ namespace Hspi
             Parser.Default.ParseArguments<Options>(args)
                 .WithParsed(options =>
                 {
-                    Console.WriteLine("Test Plugin");
-
                     // create an instance of our plugin.
                     var myPlugin = new TPlugin();
+                    Console.WriteLine(myPlugin.Name);
+
+                    if (Environment.UserInteractive)
+                    {
+                        Console.Title = myPlugin.Name;
+                    }
 
                     // Get our plugin to connect to Homeseer
                     Console.WriteLine($"\nConnecting to Homeseer at {options.Server}:{options.Port} ...");


### PR DESCRIPTION
Addresses #81 for @oesolberg 

@zshall I stole the `UserInteractive` stuff from Agent because setting `Console.Title` without the check barfs when Agent runs as a service. 